### PR TITLE
Fix/topic autocreation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules
 bundle.js
 bundle.js.map
 npm-debug.log
+yarn.lock
+package-lock.json
 coverage
 .DS_Store
 .env

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "graphql-kafka-subscriptions",
-  "version": "0.4.0",
+  "name": "@aerogear/graphql-kafka-subscriptions",
+  "version": "0.4.1",
   "description": "Apollo graphql subscription over Kafka protocol",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -12,10 +12,10 @@
   },
   "files": [
     "dist/"
-  ],  
+  ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ancashoria/graphql-kafka-subscriptions.git"
+    "url": "git+https://github.com/aerogear/graphql-kafka-subscriptions.git"
   },
   "keywords": [
     "graphql",
@@ -23,12 +23,12 @@
     "apollo",
     "subscriptions"
   ],
-  "author": "Ancas Horia",
+  "author": "Enda Phelan",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/ancashoria/graphql-kafka-subscriptions/issues"
+    "url": "https://github.com/aerogear/graphql-kafka-subscriptions/issues"
   },
-  "homepage": "https://github.com/ancashoria/graphql-kafka-subscriptions#readme",
+  "homepage": "https://github.com/aerogear/graphql-kafka-subscriptions#readme",
   "jest": {
     "roots": [
       "<rootDir>/src/test"
@@ -48,7 +48,6 @@
     "@types/node": "^13.13.2",
     "bunyan": "1.8.12",
     "dotenv": "^8.2.0",
-    "graphql": "^14.0.0",
     "graphql-subscriptions": "^1.1.0",
     "iterall": "^1.2.2",
     "node-rdkafka": "^2.8.1",
@@ -58,6 +57,9 @@
     "@types/jest": "^25.2.1",
     "jest": "^25.4.0",
     "ts-jest": "^25.4.0",
-    "typescript": "^3.8.3"    
+    "typescript": "^3.8.3"
+  },
+  "peerDependencies": {
+    "graphql": "14.x || 15.x"
   }
 }

--- a/src/kafka-pubsub.ts
+++ b/src/kafka-pubsub.ts
@@ -164,13 +164,7 @@ export class KafkaPubSub extends PubSubEngine {
         let topics =  metadata.topics.map(topic => topic.name);
         this.logger.info('Connected, found topics: %s', topics);
         
-        if (topics.includes(this.options.topic)) {
-          resolve(producer);
-        } else {
-          this.logger.error('Could not find requested topic %s', this.options.topic);
-          producer.disconnect()
-          reject('Could not find requested topic %s')
-        }
+        resolve(producer);
       })
 
       this.logger.info("Connecting producer ...")
@@ -232,16 +226,10 @@ export class KafkaPubSub extends PubSubEngine {
         let topics =  metadata.topics.map(topic => topic.name);
         this.logger.info('Connected, found topics: %s', topics);
         
-        if (topics.includes(topic)) {
-          this.logger.info("Subscribing to %s", topic)
+        this.logger.info("Subscribing to %s", topic)
           consumer.subscribe([topic]);
           consumer.consume();
           resolve(consumer);
-        } else {
-          this.logger.error('Could not find requested topic %s', topic);
-          consumer.disconnect()
-          reject('Could not find requested topic %s')
-        }
       })
 
       this.logger.info("Connecting consumer ...")


### PR DESCRIPTION
Currently this engine throws an error if a topic does not exist. This happens within the PubSub library on user application, not in Kafka server).

It is possible to configure topic auto-creation in Kafka with the `auto.topic.create.enable` flag. However because the validation was happening from this library, it was rejected too early and was never able to be created. This does not respect the Kafka server configuration.

It is much simpler and better to let the Kafka server handle this validation.. 

I have verified that this works as expected with auto topic creation enabled and disabled.