### PR TITLE
build: exclude test files from compiled package

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,14 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "baseUrl": ".",
-    "lib": ["es6", "esnext"]
+    "lib": [
+      "es6",
+      "esnext"
+    ]
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "src/test",
+    "dist"
+  ]
 }


### PR DESCRIPTION
This excludes test files from being excluded in the built `dist` folder